### PR TITLE
Feature/imports

### DIFF
--- a/examples/Ex01_simple/simple_example.py
+++ b/examples/Ex01_simple/simple_example.py
@@ -9,213 +9,83 @@ developed by Felix Panitz* and Peter Stange*
 import numpy as np
 import datetime
 
-from flixOpt import *
-from flixOpt.linear_converters import Boiler, CHP
+import flixOpt as fx
 
-### some Solver-Inputs: ###
-displaySolverOutput = False # ausführlicher Solver-Output.
-displaySolverOutput = True  # ausführlicher Solver-Output.
-gapFrac = 0.0001 # solver-gap
-timelimit = 3600 # seconds until solver abort
-# choose the solver, you have installed:
-# solver_name = 'glpk' # warning, glpk quickly has numerical problems with binaries (big and epsilon)
-# solver_name = 'gurobi'
-solver_name = 'highs'
-solverProps = {'mip_gap': gapFrac,
-               'time_limit_seconds': timelimit,
-               'solver_name': solver_name,
-               'solver_output_to_console' : displaySolverOutput,
-               }
+# Creating Time Series Data
+heat_demand_per_h = np.array([30., 0., 90., 110, 110, 20, 20, 20, 20])
+power_prices = 1 / 1000 * np.array([80., 80., 80., 80, 80, 80, 80, 80, 80])
+time_series = (datetime.datetime(2020, 1, 1) +
+               np.arange(len(heat_demand_per_h)) * datetime.timedelta(hours=1))  # creating timeseries
+time_series = time_series.astype('datetime64')  # needed format for timeseries in flixOpt
 
-#####################
-## some timeseries ##
-Q_th_Last = np.array([30., 0., 90., 110, 110 , 20, 20, 20, 20]) # kW; thermal load profile in
-p_el = 1/1000*np.array([80., 80., 80., 80 , 80, 80, 80, 80, 80]) # €/kWh; feed_in tariff;
-aTimeSeries = datetime.datetime(2020, 1,1) +  np.arange(len(Q_th_Last)) * datetime.timedelta(hours=1) # creating timeseries
-aTimeSeries = aTimeSeries.astype('datetime64') # needed format for timeseries in flixOpt
-max_emissions_per_hour = 1000 # kg per timestep
+# define buses for the 3 used medias:
+Strom, Fernwaerme, Gas = fx.Bus(label='Strom'), fx.Bus(label='Fernwärme'), fx.Bus(label='Gas')  # balancing nodes
 
-print('#######################################################################')
-print('################### start of modeling #################################')
+costs = fx.Effect(label='costs', unit='€', description='Kosten',
+                  is_standard=True,  # standard effect --> effect values not passed as a dict are treated as costs
+                  is_objective=True)  # costs are the objective of optimization (get minimized
 
-# #####################
-# ## Bus-Definition: ##
-# define buses for the 3 used media:
-Strom = Bus('el', 'Strom') # balancing node/bus of electricity
-Fernwaerme = Bus('heat', 'Fernwärme') # balancing node/bus of heat
-Gas = Bus('fuel', 'Gas') # balancing node/bus of gas
+CO2 = fx.Effect(label='CO2', unit='kg', description='CO2_e-Emissionen',
+                specific_share_to_other_effects_operation={costs: 0.2},
+                # unit of CO2 in operation has an effect of 0.2 units of costs
+                maximum_operation_per_hour=1000)  # Maximum CO2 per hour
 
-# ########################
-# ## Effect-Definition: ##
-costs = Effect('costs', '€', 'Kosten',  # name, unit, description
-               is_standard= True,  # standard effect --> shorter input possible (without effect as a key)
-               is_objective= True) # defining costs as objective of optimiziation
+boiler = fx.linear_converters.Boiler(label='Boiler', eta=0.5,
+                                     Q_th=fx.Flow(label='Q_th',
+                                                  bus=Fernwaerme,
+                                                  size=50,
+                                                  relative_minimum=0.1,
+                                                  relative_maximum=1),
+                                     Q_fu=fx.Flow(label='Q_fu',
+                                                  bus=Gas))
 
-CO2   = Effect('CO2', 'kg', 'CO2_e-Emissionen',  # name, unit, description
-               specific_share_to_other_effects_operation= {costs: 0.2}, maximum_operation_per_hour= max_emissions_per_hour) # 0.2 €/kg; defining links between effects, here CO2-price
+chp = fx.linear_converters.CHP(label='CHP', eta_th=0.5, eta_el=0.4,
+                               P_el=fx.Flow('P_el', bus=Strom,
+                                            size=60,  # 60 kW_el
+                                            relative_minimum=5/60),  # minimum load of 5 kW_el
+                               Q_th=fx.Flow('Q_th', bus=Fernwaerme),
+                               Q_fu=fx.Flow('Q_fu', bus=Gas))
 
-# ###########################
-# ## Component-Definition: ##
+storage = fx.Storage(label='Storage',
+                     charging=fx.Flow('Q_th_load', bus=Fernwaerme, size=1000),
+                     discharging=fx.Flow('Q_th_unload', bus=Fernwaerme, size=1000),
+                     capacity_in_flow_hours=fx.InvestParameters(fix_effects=20,
+                                                                fixed_size=30,
+                                                                optional=False),
+                     initial_charge_state=0,  # empty storage at first time step
+                     relative_maximum_charge_state=1 / 100 * np.array([80., 70., 80., 80, 80, 80, 80, 80, 80, 80]),
+                     eta_charge=0.9, eta_discharge=1,  # loading efficiency factor, unloading efficiency factor
+                     relative_loss_per_hour=0.08,  # 8 %/h; 8 percent of storage loading level is lost every hour
+                     prevent_simultaneous_charge_and_discharge=True,  # no parallel loading and unloading at one time
+                     )
 
-# # 1. heat supply units: #
+heat_sink = fx.Sink(label='Heat Demand',
+                    sink=fx.Flow(label='Q_th_Last',
+                                 bus=Fernwaerme,
+                                 size=1,
+                                 relative_maximum=max(heat_demand_per_h),
+                                 fixed_relative_value=heat_demand_per_h))  # fixed profile
 
-# 1.a) defining a boiler
-aBoiler = Boiler('Boiler', eta = 0.5,  # name, efficiency factor
-                 # defining the output-flow = thermal -flow
-                 Q_th = Flow(label ='Q_th',  # name of flow
-                             bus = Fernwaerme,  # define, where flow is linked to (here: Fernwaerme-Bus)
-                             size=50,  # kW; nominal_size of boiler
-                             relative_minimum = 5/50,  # 10 % minimum load, i.e. 5 kW
-                             relative_maximum = 1,  # 100 % maximum load, i.e. 50 kW
-                             ),
-                 # defining the input-flow = fuel-flow
-                 Q_fu = Flow(label ='Q_fu',  # name of flow
-                             bus = Gas)  # define, where flow is linked to (here: Gas-Bus)
-                 )
-
-# 2.b) defining a CHP unit:
-aKWK  = CHP('CHP_unit', eta_th = 0.5, eta_el = 0.4,  # name, thermal efficiency, electric efficiency
-            # defining flows:
-            P_el = Flow('P_el', bus = Strom,
-                        size=60,  # 60 kW_el
-                        relative_minimum = 5/60, ),  # 5 kW_el, min- and max-load (100%) are here defined through this electric flow
-            Q_th = Flow('Q_th', bus = Fernwaerme),
-            Q_fu = Flow('Q_fu', bus = Gas))
-
-# # 2. storage #
-
-aSpeicher = Storage('Speicher',
-                    charging= Flow('Q_th_load', bus = Fernwaerme, size=1e4),  # load-flow, maximum load-power: 1e4 kW
-                    discharging= Flow('Q_th_unload', bus = Fernwaerme, size=1e4),  # unload-flow, maximum load-power: 1e4 kW
-                    capacity_in_flow_hours=InvestParameters(fix_effects=20, fixed_size=30, optional=False),  # 30 kWh; storage capacity
-                    initial_charge_state=0,  # empty storage at first time step
-                    relative_maximum_charge_state=1 / 100 * np.array([80., 70., 80., 80 , 80, 80, 80, 80, 80, 80]),
-                    eta_load=0.9, eta_unload=1,  #loading efficiency factor, unloading efficiency factor
-                    relative_loss_per_hour=0.08,  # 8 %/h; 8 percent of storage loading level is lossed every hour
-                    prevent_simultaneous_charge_and_discharge=True,  # no parallel loading and unloading at one time
-                    )
- 
-# # 3. sinks and sources #
-
-# sink of heat load:
-aWaermeLast = Sink('Wärmelast',
-                   # defining input-flow:
-                   sink   = Flow('Q_th_Last',  # name
-                                 bus = Fernwaerme,  # linked to bus "Fernwaerme"
-                                 size=1,  # sizeue
-                                 fixed_relative_value = Q_th_Last)) # fixed profile
-                                   # relative fixed values (timeseries) of the flow
-                                   # value = fixed_relative_value * size
-    
 # source of gas:
-aGasTarif = Source('Gastarif',
-                   # defining output-flow:
-                   source = Flow('Q_Gas',  # name
-                                 bus = Gas,  # linked to bus "Gas"
-                                 size=1000,  # nominal size, i.e. 1000 kW maximum
-                                 # defining effect-shares.
-                                 #    Here not only "costs", but also CO2-emissions:
-                                 effects_per_flow_hour= {costs: 0.04, CO2: 0.3})) # 0.04 €/kWh, 0.3 kg_CO2/kWh
+gas_source = fx.Source(label='Gastarif',
+                       source=fx.Flow(label='Q_Gas',
+                                      bus=Gas,
+                                      size=1000,
+                                      effects_per_flow_hour={costs: 0.04, CO2: 0.3}))  # 0.04 €/kWh, 0.3 kg_CO2/kWh
 
-# sink of electricity feed-in:
-aStromEinspeisung = Sink('Einspeisung',
-                         # defining input-flow:
-                         sink=Flow('P_el',  # name
-                                   bus = Strom,  # linked to bus "Strom"
-                                   effects_per_flow_hour=-1 * p_el)) # gains (negative costs) per kWh
+power_sink = fx.Sink(label='Einspeisung',
+                     sink=fx.Flow(label='P_el',
+                                  bus=Strom,
+                                  effects_per_flow_hour=-1 * power_prices))
 
+flow_system = fx.FlowSystem(time_series=time_series)
+flow_system.add_elements(costs, CO2, boiler, storage, chp, heat_sink, gas_source, power_sink)
 
-# ######################################################
-# ## Build energysystem - Registering of all elements ##
+calculation = fx.FullCalculation(name='Sim1',  # name of calculation
+                                 flow_system=flow_system,  # flow_system to calculate
+                                 modeling_language='pyomo')  # optimization modeling language (only "pyomo" implemented, yet)
+calculation.do_modeling()  # Translating the Model to be solvable
+calculation.solve(fx.solvers.HighsSolver(), save_results=True)
 
-flow_system = FlowSystem(aTimeSeries, last_time_step_hours=None) # creating flow_system, (duration of last timestep is like the one before)
-flow_system.add_components(aSpeicher) # adding components
-flow_system.add_effects(costs, CO2) # adding defined effects
-flow_system.add_components(aBoiler, aWaermeLast, aGasTarif) # adding components
-flow_system.add_components(aStromEinspeisung) # adding components
-flow_system.add_components(aKWK) # adding components
-
-
-# choose used timeindexe:
-time_indices = None # all timeindexe are used
-# time_indices = [1,3,5] # only a subset shall be used
-
-# ## modeling the flow_system ##
-
-# 1. create a Calculation 
-aCalc = FullCalculation('Sim1',  # name of calculation
-                    flow_system,  # energysystem to calculate
-                     'pyomo',  # optimization modeling language (only "pyomo" implemented, yet)
-                    time_indices) # used time steps
-
-# 2. modeling:
-aCalc.do_modeling() # mathematic modeling of flow_system
-
-# 3. (optional) print Model-Characteristics:
-flow_system.print_model() # string-output:network structure of model
-flow_system.print_variables() # string output: variables of model
-flow_system.print_equations() # string-output: equations of model
-
-
-# #################
-# ## calculation ##
-
-aCalc.solve(solverProps)
-# .. results are saved under /results/
-# these files are written:
-# -> json-file with model- and solve-Informations!
-# -> log-file
-# -> data-file
-
-
-# ####################
 # # PostProcessing: ##
-# ####################
-
-
-# ##### loading results from output-files ######
-import flixOpt.postprocessing as flixPost
-
-label = aCalc.name
-print(label)
-# loading results, creating postprocessing Object:
-aCalc_post = flixPost.flix_results(label) 
-
-# ## plotting ##
-# plotting all in- and out-flows of bus "Fernwaerme":
-fig1 = aCalc_post.plotInAndOuts('Fernwaerme',stacked=True)
-fig1.savefig('results/test1')
-fig2 = aCalc_post.plotInAndOuts('Fernwaerme',stacked=True, plotAsPlotly = True)
-fig2.show()
-fig2.write_html('results/test2.html')
-fig3 = aCalc_post.plotInAndOuts('Strom',stacked=True, plotAsPlotly = True)
-fig3.show()
-fig4 = aCalc_post.plotShares('Fernwaerme',plotAsPlotly=True)
-fig4.show()
-
-
-##############################
-# ## access to timeseries: ##
-
-# 1. direct access:
-# (not recommended, better use postProcessing instead, see next)
-print('# direct access:')
-print('way 1:')
-print(aCalc.results['Boiler']['Q_th']['val']) # access through dict
-print('way 2:')
-print(aBoiler.Q_th.model.variables["val"].result) # access directly through component/flow-variables
-#    (warning: there are only temporarily the results of the last executed solve-command of the flow_system)
-
-# 2. post-processing access:
-print('# access to timeseries:#')
-print('way 1:')
-print(aCalc_post.results['Boiler']['Q_th']['val']) # access through dict
-print('way 2:')
-# find flow:
-aFlow_post = aCalc_post.getFlowsOf('Fernwaerme','Boiler')[0][0] # getting flow
-print(aFlow_post.results['val']) # access through cFlow_post object
-
-# ###############################################
-# ## saving csv of special flows of bus "Fernwaerme" ##
-aCalc_post.to_csv('Fernwaerme', 'results/FW.csv')
-    
+#TODO: Adopt fx.results to new structure

--- a/flixOpt/__init__.py
+++ b/flixOpt/__init__.py
@@ -5,13 +5,5 @@ Created on Tue Feb 16 09:16:58 2021
 @author: Panitz
 """
 
-from flixOpt.elements import Flow, Bus
-from flixOpt.effects import Effect
-from flixOpt.components import Source, Sink, SourceAndSink, Storage, LinearConverter
-from flixOpt.flow_system import FlowSystem
-from flixOpt.calculation import FullCalculation, SegmentedCalculation, AggregatedCalculation
-from flixOpt.interface import InvestParameters, OnOffParameters
-from flixOpt.postprocessing import flix_results
-from flixOpt import solvers
-from flixOpt.core import setup_logging, change_logging_level, TimeSeriesData
+from .commons import *
 setup_logging('INFO')

--- a/flixOpt/aggregation.py
+++ b/flixOpt/aggregation.py
@@ -18,16 +18,13 @@ import pandas as pd
 import numpy as np
 import tsam.timeseriesaggregation as tsam
 
-from flixOpt.core import Skalar, TimeSeries
-from flixOpt.elements import Flow, Component
-from flixOpt.flow_system import FlowSystem
-from flixOpt.components import Storage
-from flixOpt.core import TimeSeriesData
-from flixOpt.structure import Element, SystemModel, ElementModel, create_variable, create_equation
-from flixOpt.math_modeling import Equation, Variable, VariableTS
-
-if TYPE_CHECKING:
-    from flixOpt.effects import EffectCollection
+from .core import Skalar, TimeSeries
+from .elements import Component
+from .flow_system import FlowSystem
+from .components import Storage
+from .core import TimeSeriesData
+from .structure import Element, SystemModel, ElementModel, create_variable, create_equation
+from .math_modeling import Equation, Variable, VariableTS
 
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)

--- a/flixOpt/calculation.py
+++ b/flixOpt/calculation.py
@@ -14,14 +14,14 @@ from typing import List, Dict, Optional, Literal, Union, Any
 
 import numpy as np
 
-from flixOpt.aggregation import TimeSeriesCollection, AggregationParameters, AggregationModel
-from flixOpt.core import Numeric, Skalar
-from flixOpt.structure import SystemModel
-from flixOpt.flow_system import FlowSystem
-from flixOpt.elements import Component
-from flixOpt.components import Storage
-from flixOpt.features import InvestmentModel
-from flixOpt.solvers import Solver
+from .aggregation import TimeSeriesCollection, AggregationParameters, AggregationModel
+from .core import Numeric, Skalar
+from .structure import SystemModel
+from .flow_system import FlowSystem
+from .elements import Component
+from .components import Storage
+from .features import InvestmentModel
+from .solvers import Solver
 
 
 logger = logging.getLogger('flixOpt')
@@ -182,7 +182,7 @@ class AggregatedCalculation(Calculation):
         for time_series in self.flow_system.all_time_series:
             time_series.activate_indices(self.time_indices)
 
-        from flixOpt.aggregation import Aggregation
+        from .aggregation import Aggregation
 
         (chosenTimeSeries, chosenTimeSeriesWithEnd, dt_in_hours, dt_in_hours_total) = (
             self.flow_system.get_time_data_from_indices(self.time_indices))

--- a/flixOpt/commons.py
+++ b/flixOpt/commons.py
@@ -1,11 +1,17 @@
 # -*- coding: utf-8 -*-
 
+from .core import setup_logging, change_logging_level, TimeSeriesData
+
 from .elements import Flow, Bus
 from .effects import Effect
 from .components import Source, Sink, SourceAndSink, Storage, LinearConverter
+from . import linear_converters
+
 from .flow_system import FlowSystem
 from .calculation import FullCalculation, SegmentedCalculation, AggregatedCalculation
-from .interface import InvestParameters, OnOffParameters
-from .postprocessing import flix_results
 from . import solvers
-from .core import setup_logging, change_logging_level, TimeSeriesData
+
+from .interface import InvestParameters, OnOffParameters
+from .aggregation import AggregationParameters
+
+from .postprocessing import flix_results

--- a/flixOpt/commons.py
+++ b/flixOpt/commons.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+from .elements import Flow, Bus
+from .effects import Effect
+from .components import Source, Sink, SourceAndSink, Storage, LinearConverter
+from .flow_system import FlowSystem
+from .calculation import FullCalculation, SegmentedCalculation, AggregatedCalculation
+from .interface import InvestParameters, OnOffParameters
+from .postprocessing import flix_results
+from . import solvers
+from .core import setup_logging, change_logging_level, TimeSeriesData

--- a/flixOpt/components.py
+++ b/flixOpt/components.py
@@ -10,14 +10,14 @@ import textwrap
 import logging
 from typing import Union, Optional, Literal, List, Dict, Tuple, Set
 
-from flixOpt import utils
-from flixOpt.elements import Flow, _create_time_series
-from flixOpt.core import Skalar, Numeric_TS, TimeSeries, Numeric
-from flixOpt.math_modeling import VariableTS, Equation
-from flixOpt.features import OnOffModel, MultipleSegmentsModel, InvestmentModel
-from flixOpt.structure import SystemModel, create_equation, create_variable
-from flixOpt.elements import Component, ComponentModel
-from flixOpt.interface import InvestParameters, OnOffParameters
+from . import utils
+from .elements import Flow, _create_time_series
+from .core import Skalar, Numeric_TS, TimeSeries, Numeric
+from .math_modeling import VariableTS, Equation
+from .features import OnOffModel, MultipleSegmentsModel, InvestmentModel
+from .structure import SystemModel, create_equation, create_variable
+from .elements import Component, ComponentModel
+from .interface import InvestParameters, OnOffParameters
 
 logger = logging.getLogger('flixOpt')
 

--- a/flixOpt/core.py
+++ b/flixOpt/core.py
@@ -9,7 +9,7 @@ import logging
 
 import numpy as np
 
-from flixOpt import utils
+from . import utils
 
 logger = logging.getLogger('flixOpt')
 

--- a/flixOpt/effects.py
+++ b/flixOpt/effects.py
@@ -5,19 +5,15 @@ developed by Felix Panitz* and Peter Stange*
 * at Chair of Building Energy Systems and Heat Supply, Technische Universität Dresden
 """
 
-from typing import List, Tuple, Dict, Union, Optional, Literal, TYPE_CHECKING
+from typing import List, Dict, Union, Optional, Literal
 import logging
 
 import numpy as np
 
-from flixOpt.math_modeling import Variable, Equation
-from flixOpt.core import TimeSeries, Skalar, Numeric, Numeric_TS, as_effect_dict
-from flixOpt.features import ShareAllocationModel
-from flixOpt.structure import Element, ElementModel, SystemModel, _create_time_series
-
-if TYPE_CHECKING:  # for type checking and preventing circular imports
-    from flixOpt.flow_system import FlowSystem
-    from flixOpt.features import ComponentModel, BusModel
+from .math_modeling import Variable, Equation
+from .core import TimeSeries, Skalar, Numeric, Numeric_TS, as_effect_dict
+from .features import ShareAllocationModel
+from .structure import Element, ElementModel, SystemModel, _create_time_series
 
 
 logger = logging.getLogger('flixOpt')

--- a/flixOpt/effects.py
+++ b/flixOpt/effects.py
@@ -314,7 +314,6 @@ class EffectCollectionModel(ElementModel):
         self.add_share_between_effects()
 
         self.objective = Equation('OBJECTIVE', 'OBJECTIVE', 'objective')
-        self.add_equations(self.objective)
         self.objective.add_summand(self._objective_effect_model.operation.sum, 1)
         self.objective.add_summand(self._objective_effect_model.invest.sum, 1)
         self.objective.add_summand(self.penalty.sum, 1)

--- a/flixOpt/elements.py
+++ b/flixOpt/elements.py
@@ -6,18 +6,17 @@ developed by Felix Panitz* and Peter Stange*
 """
 
 import textwrap
-from typing import List, Set, Tuple, Dict, Union, Optional, Literal, TYPE_CHECKING
+from typing import List, Tuple, Union, Optional, Literal, TYPE_CHECKING
 import logging
 
 import numpy as np
 
-from flixOpt import utils
-from flixOpt.math_modeling import Variable, VariableTS, Equation
-from flixOpt.core import TimeSeries, Numeric, Numeric_TS, Skalar
-from flixOpt.interface import InvestParameters, OnOffParameters
-from flixOpt.features import OnOffModel, InvestmentModel, PreventSimultaneousUsageModel
-from flixOpt.structure import SystemModel, Element, ElementModel, _create_time_series, create_equation, create_variable
-from flixOpt.effects import EffectValues, effect_values_to_time_series, EffectCollectionModel
+from .math_modeling import Variable, VariableTS
+from .core import Numeric, Numeric_TS, Skalar
+from .interface import InvestParameters, OnOffParameters
+from .features import OnOffModel, InvestmentModel, PreventSimultaneousUsageModel
+from .structure import SystemModel, Element, ElementModel, _create_time_series, create_equation, create_variable
+from .effects import EffectValues, effect_values_to_time_series
 
 logger = logging.getLogger('flixOpt')
 

--- a/flixOpt/features.py
+++ b/flixOpt/features.py
@@ -10,15 +10,15 @@ import logging
 
 import numpy as np
 
-from flixOpt.math_modeling import Variable, VariableTS, Equation
-from flixOpt.core import TimeSeries, Skalar, Numeric, Numeric_TS
-from flixOpt.interface import InvestParameters, OnOffParameters
-from flixOpt.structure import ElementModel, SystemModel, Element, create_equation, create_variable
+from .math_modeling import Variable, VariableTS, Equation
+from .core import TimeSeries, Skalar, Numeric
+from .interface import InvestParameters, OnOffParameters
+from .structure import ElementModel, SystemModel, Element, create_equation, create_variable
 
 if TYPE_CHECKING:  # for type checking and preventing circular imports
-    from flixOpt.effects import Effect
-    from flixOpt.elements import Flow
-    from flixOpt.components import Storage
+    from .effects import Effect
+    from .elements import Flow
+    from .components import Storage
 
 
 logger = logging.getLogger('flixOpt')

--- a/flixOpt/flow_system.py
+++ b/flixOpt/flow_system.py
@@ -9,13 +9,12 @@ from typing import List, Set, Tuple, Dict, Union, Optional
 import logging
 
 import numpy as np
-import yaml  # (für json-Schnipsel-print)
 
-from flixOpt import utils
-from flixOpt.core import TimeSeries
-from flixOpt.structure import Element, SystemModel
-from flixOpt.elements import Bus, Flow, Component
-from flixOpt.effects import Effect, EffectCollection
+from . import utils
+from .core import TimeSeries
+from .structure import Element, SystemModel
+from .elements import Bus, Flow, Component
+from .effects import Effect, EffectCollection
 
 logger = logging.getLogger('flixOpt')
 

--- a/flixOpt/interface.py
+++ b/flixOpt/interface.py
@@ -7,12 +7,10 @@ developed by Felix Panitz* and Peter Stange*
 import logging
 from typing import Union, Optional, Dict, List, Tuple, TYPE_CHECKING
 
-import numpy as np
-
-from flixOpt.core import Numeric, Skalar, Numeric_TS
+from .core import Numeric, Skalar, Numeric_TS
 if TYPE_CHECKING:
-    from flixOpt.structure import Element
-    from flixOpt.effects import EffectTimeSeries, EffectValues, EffectValuesInvest
+    from .structure import Element
+    from .effects import EffectTimeSeries, EffectValues, EffectValuesInvest
 
 logger = logging.getLogger('flixOpt')
 
@@ -77,7 +75,7 @@ class InvestParameters:
         self._maximum_size = maximum_size
     
     def transform_data(self):
-        from flixOpt.effects import as_effect_dict
+        from .effects import as_effect_dict
         self.fix_effects = as_effect_dict(self.fix_effects)
         self.divest_effects = as_effect_dict(self.divest_effects)
         self.specific_effects = as_effect_dict(self.specific_effects)
@@ -158,8 +156,8 @@ class OnOffParameters:
         self.force_switch_on = force_switch_on
 
     def transform_data(self, owner: 'Element'):
-        from flixOpt.effects import effect_values_to_time_series
-        from flixOpt.structure import _create_time_series
+        from .effects import effect_values_to_time_series
+        from .structure import _create_time_series
         self.effects_per_switch_on = effect_values_to_time_series('per_switch_on', self.effects_per_switch_on, owner)
         self.effects_per_running_hour = effect_values_to_time_series('per_running_hour', self.effects_per_running_hour, owner)
         self.consecutive_on_hours_min = _create_time_series('consecutive_on_hours_min', self.consecutive_on_hours_min, owner)

--- a/flixOpt/math_modeling.py
+++ b/flixOpt/math_modeling.py
@@ -358,6 +358,7 @@ class MathModel:
         self._variables: List[Variable] = []
         self._eqs: List[Equation] = []
         self._ineqs: List[Equation] = []
+        self._objective: Optional[Equation] = None
         self.result_of_objective: Optional[float] = None
 
         self.duration = {}
@@ -373,6 +374,8 @@ class MathModel:
                     self._eqs.append(arg)
                 elif arg.eqType == 'ineq':
                     self._ineqs.append(arg)
+                elif arg.eqType == 'objective':
+                    self._objective = arg
                 else:
                     raise Exception(f'{arg} cant be added this way!')
             else:
@@ -398,7 +401,7 @@ class MathModel:
         for variable in self.variables:
             variable.reset_result()  # altes Ergebnis löschen (falls vorhanden)
         self.model.solve(self, solver)
-        self.duration['solve'] = round(timeit.default_timer() - t_start, 2)
+        self.duration['Solving'] = round(timeit.default_timer() - t_start, 2)
 
     @property
     def infos(self) -> Dict:
@@ -431,6 +434,10 @@ class MathModel:
     @property
     def ineqs(self) -> List[Equation]:
         return self._ineqs
+
+    @property
+    def objective(self) -> Equation:
+        return self._objective
 
     @property
     def ts_variables(self) -> List[VariableTS]:
@@ -781,7 +788,7 @@ class ModelingLanguage(ABC):
     def translate_model(self, model: MathModel):
         raise NotImplementedError
 
-    def solve(self, math_model: MathModel, solver_opt: Dict):
+    def solve(self, math_model: MathModel, solver: Solver):
         raise NotImplementedError
 
 
@@ -800,14 +807,15 @@ class PyomoModel(ModelingLanguage):
         global pyomoEnv  # als globale Variable
         import pyomo.environ as pyomoEnv
         logger.debug('Loaded pyomo modules')
-        # für den Fall pyomo wird EIN Modell erzeugt, das auch für rollierende Durchläufe immer wieder genutzt wird.
+
         self.model = pyomoEnv.ConcreteModel(name="(Minimalbeispiel)")
 
         self.mapping: Dict[Union[Variable, Equation], Any] = {}  # Mapping to Pyomo Units
         self._counter = 0
 
     def solve(self, math_model: MathModel, solver: Solver):
-        self.translate_model(math_model)
+        if self._counter == 0:
+            raise Exception(f' First, call .translate_model(). Else PyomoModel cant solve()')
         solver.solve(self)
 
         # write results
@@ -837,6 +845,10 @@ class PyomoModel(ModelingLanguage):
             logger.debug(f'INEQ {ineq.label} gets translated to Pyomo')
             self.translate_equation(ineq)
 
+        obj = math_model.objective
+        logger.debug(f'{obj.label} gets translated to Pyomo')
+        self.translate_objective(obj)
+
     def translate_variable(self, variable: Variable):
         assert isinstance(variable, Variable), 'Wrong type of variable'
 
@@ -864,50 +876,45 @@ class PyomoModel(ModelingLanguage):
                 pyomo_comp[i].setub(upper_bound_vector[i])  # max
 
     def translate_equation(self, equation: Equation):
+        if equation.eqType not in ['eq', 'ineq']:
+            raise TypeError(f'Wrong equation type: {equation.eqType}')
 
         # constant_vector hier erneut erstellen, da Anz. Glg. vorher noch nicht bekannt:
         constant_vector = equation.constant_vector
-        # 1. Constraints:
-        if equation.eqType in ['eq', 'ineq']:
-            model = self.model
+        model = self.model
 
-            # lineare Summierung für i-te Gleichung:
-            def linear_sum_pyomo_rule(model, i):
-                lhs = 0
-                aSummand: Summand
-                for aSummand in equation.summands:
-                    lhs += self._summand_math_expression(aSummand, i)  # i-te Gleichung (wenn Skalar, dann wird i ignoriert)
-                rhs = constant_vector[i]
-                # Unterscheidung return-value je nach typ:
-                if equation.eqType == 'eq':
-                    return lhs == rhs
-                elif equation.eqType == 'ineq':
-                    return lhs <= rhs
+        # lineare Summierung für i-te Gleichung:
+        def linear_sum_pyomo_rule(model, i):
+            lhs = 0
+            aSummand: Summand
+            for aSummand in equation.summands:
+                lhs += self._summand_math_expression(aSummand, i)  # i-te Gleichung (wenn Skalar, dann wird i ignoriert)
+            rhs = constant_vector[i]
+            # Unterscheidung return-value je nach typ:
+            if equation.eqType == 'eq':
+                return lhs == rhs
+            elif equation.eqType == 'ineq':
+                return lhs <= rhs
 
-            pyomo_comp = pyomoEnv.Constraint(range(equation.length),
-                                             rule=linear_sum_pyomo_rule)  # Nebenbedingung erstellen
+        pyomo_comp = pyomoEnv.Constraint(range(equation.length),
+                                         rule=linear_sum_pyomo_rule)  # Nebenbedingung erstellen
 
-            self._register_pyomo_comp(pyomo_comp, equation)
+        self._register_pyomo_comp(pyomo_comp, equation)
 
-        # 2. Zielfunktion:
-        elif equation.eqType == 'objective':
-            # Anmerkung: nrOfEquation - Check könnte auch weiter vorne schon passieren!
-            if equation.length > 1:
-                raise Exception('Equation muss für objective ein Skalar ergeben!!!')
+    def translate_objective(self, objective: Equation):
+        if not objective.eqType == 'objective':
+            raise TypeError(f'Equation of type {objective.eqType} passed to translate_objective. Must be objective!')
+        if objective.length != 1:
+            raise Exception('Length of Objective must be 0')
 
-            # Summierung der Skalare:
-            def linearSumRule_Skalar(model):
-                skalar = 0
-                for aSummand in equation.summands:
-                    skalar += self._summand_math_expression(aSummand)
-                return skalar
+        def linearSumRule_Skalar(model):
+            skalar = 0
+            for summand in objective.summands:
+                skalar += self._summand_math_expression(summand)
+            return skalar
 
-            self.model.objective = pyomoEnv.Objective(rule=linearSumRule_Skalar, sense=pyomoEnv.minimize)
-            self.mapping[equation] = self.model.objective
-
-        # 3. Undefined:
-        else:
-            raise Exception('equation.eqType= ' + str(equation.eqType) + ' nicht definiert')
+        self.model.objective = pyomoEnv.Objective(rule=linearSumRule_Skalar, sense=pyomoEnv.minimize)
+        self.mapping[objective] = self.model.objective
 
     def _summand_math_expression(self, summand: Summand, at_index: int = 0) -> 'pyomoEnv.Expression':
         pyomo_variable = self.mapping[summand.variable]

--- a/flixOpt/math_modeling.py
+++ b/flixOpt/math_modeling.py
@@ -14,8 +14,8 @@ from abc import ABC, abstractmethod
 import numpy as np
 from pyomo.contrib import appsi
 
-from flixOpt import utils
-from flixOpt.core import Skalar, Numeric
+from . import utils
+from .core import Numeric
 
 pyomoEnv = None  # das ist module, das nur bei Bedarf belegt wird
 

--- a/flixOpt/postprocessing.py
+++ b/flixOpt/postprocessing.py
@@ -14,7 +14,7 @@ import pandas as pd
 import matplotlib.pyplot as plt  # für Plots im Postprocessing
 import matplotlib.dates as mdates
 
-from flixOpt import utils
+from . import utils
 
 logger = logging.getLogger('flixOpt')
 
@@ -627,7 +627,7 @@ class flix_results():
 
             # gestapelt:
             if stacked:
-                from flixOpt.plotting import plotStackedSteps
+                from .plotting import plotStackedSteps
                 plotStackedSteps(ax, y)  # legende here automatically
             # normal:
             else:

--- a/flixOpt/solvers.py
+++ b/flixOpt/solvers.py
@@ -7,4 +7,4 @@ developed by Felix Panitz* and Peter Stange*
 
 # This module is simply for convenience
 
-from flixOpt.math_modeling import Solver, HighsSolver, GurobiSolver, CbcSolver, CplexSolver, GlpkSolver
+from .math_modeling import Solver, HighsSolver, GurobiSolver, CbcSolver, CplexSolver, GlpkSolver

--- a/flixOpt/structure.py
+++ b/flixOpt/structure.py
@@ -206,6 +206,10 @@ class SystemModel(MathModel):
         """ Needed for Mother class """
         return list(self.all_equations.values())
 
+    @property
+    def objective(self) -> Equation:
+        return self.effect_collection_model.objective
+
 
 class Element:
     """ Basic Element of flixOpt"""
@@ -372,7 +376,7 @@ def _create_time_series(label: str, data: Optional[Union[Numeric_TS, TimeSeries]
 
 
 def create_equation(label: str, element_model: ElementModel, system_model: SystemModel,
-                    eq_type: Literal['eq', 'ineq', 'objective'] = 'eq') -> Equation:
+                    eq_type: Literal['eq', 'ineq'] = 'eq') -> Equation:
     """ Creates an Equation and adds it to the model of the Element """
     eq = Equation(f'{element_model.label_full}_{label}', label, eq_type)
     element_model.add_equations(eq)

--- a/flixOpt/structure.py
+++ b/flixOpt/structure.py
@@ -5,18 +5,18 @@ developed by Felix Panitz* and Peter Stange*
 * at Chair of Building Energy Systems and Heat Supply, Technische Universität Dresden
 """
 
-from typing import List, Tuple, Dict, Union, Optional, Literal, TYPE_CHECKING
+from typing import List, Dict, Union, Optional, Literal, TYPE_CHECKING
 import logging
 
 import numpy as np
 
-from flixOpt import utils
-from flixOpt.math_modeling import MathModel, Variable, Equation, VariableTS, Solver
-from flixOpt.core import TimeSeries, Skalar, Numeric, Numeric_TS, as_effect_dict
+from . import utils
+from .math_modeling import MathModel, Variable, Equation, VariableTS, Solver
+from .core import TimeSeries, Skalar, Numeric, Numeric_TS
 
 if TYPE_CHECKING:  # for type checking and preventing circular imports
-    from flixOpt.flow_system import FlowSystem
-    from flixOpt.elements import ComponentModel, BusModel
+    from .flow_system import FlowSystem
+    from .elements import ComponentModel, BusModel
 
 logger = logging.getLogger('flixOpt')
 

--- a/flixOpt/utils.py
+++ b/flixOpt/utils.py
@@ -9,10 +9,6 @@ import logging
 from typing import Union, List, Optional, Dict, Literal
 
 import numpy as np
-import math  # für nan
-
-from flixOpt.core import TimeSeriesData
-from flixOpt.core import Numeric, Skalar
 
 logger = logging.getLogger('flixOpt')
 
@@ -46,19 +42,7 @@ def as_vector(value: Union[int, float, np.ndarray, List], length: int) -> np.nda
         return np.array(value)
 
 
-def check_bounds(value: Union[int, float, np.ndarray, TimeSeriesData],
-                 label: str,
-                 lower_bound: Numeric,
-                 upper_bound: Numeric):
-    if isinstance(value, TimeSeriesData):
-        value = value.data
-    if np.any(value < lower_bound):
-        raise Exception(f'{label} is below its {lower_bound=}!')
-    if np.any(value >= upper_bound):
-        raise Exception(f'{label} is above its {upper_bound=}!')
-
-
-def is_number(number_alias: Union[Skalar, str]):
+def is_number(number_alias: Union[int, float, str]):
     """ Returns True is string is a number. """
     try:
         float(number_alias)


### PR DESCRIPTION
# Streamlining the Imports in flixOpt
## flixOpt commons and the use of an alias
A new file commons.py makes the parts of flixOpt that are meant to be used by the end user available.
The new recommended usage of flixOpt is:
```
import flixOpt as fx
fx.Bus()
fx.Effect()
```
Through this, all relevant parts of flixOpt are type hinted after the 'fx.'
This should greatly improve the first hours of using the package.
The new Syntax can be seen in the updated simple_example.py.

## Other Changes:
- Changed absolute imports to relative imports throughout the package
- Moved a function out of utils.py
- removed unused imports everywhere

## Contributor
Felix Bumann